### PR TITLE
Add optional `embedded-hal-async` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,18 @@ readme = "README.md"
 version = "1.0.2"
 edition = "2021"
 
-
 [dependencies]
 embedded-hal = "1.0.0"
+embedded-hal-async = { version = "1.0.0", optional = true }
 log = "0.4"
 bitfield = "0.14"
-
-
 
 [dev-dependencies]
 embedded-hal-mock = "0.10"
 test-log = "0.2"
 env_logger = "0.11"
 approx = "0.5.1"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -26,3 +26,24 @@ fn main() -> ! {
     }
 }
 ```
+
+## [`embedded-hal-async`] usage
+
+This crate has optional support for [`embedded-hal-async`], which provides
+asynchronous versions of the [`embedded-hal`] traits. To avoid an unnecessary
+dependency on `embedded-hal-async` for projects which do not require it, the
+`embedded-hal-async` support is an optional feature.
+
+In order to use the `embedded-hal-async` driver, add the following to your
+`Cargo.toml`:
+
+```toml
+[dependencies]
+bosch-bme680 = { version = "1.0.3", features = ["embedded-hal-async"] }
+```
+
+Then, construct an instance of the `AsyncBme680` struct using the
+`embedded_hal_async` `I2c` and `Delay` traits.
+
+[`embedded-hal`]: https://crates.io/crates/embedded-hal-async
+[`embedded-hal-async`]: https://crates.io/crates/embedded-hal-async

--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -1,0 +1,147 @@
+use self::i2c_helper::I2CHelper;
+use crate::bitfields::RawConfig;
+use crate::config::{Configuration, SensorMode, Variant};
+use crate::constants::LEN_CONFIG;
+use crate::data::CalibrationData;
+use crate::BmeError;
+use crate::DeviceAddress;
+use crate::MeasurmentData;
+use embedded_hal_async::{
+    delay::DelayNs,
+    i2c::{I2c, SevenBitAddress},
+};
+mod i2c_helper;
+
+/// Asynchronous BME680 sensor driver.
+///
+/// This struct is similar to the [`Bme680`](crate::Bme680) type, except that it
+/// uses the [`embedded_hal_async`] crate's `I2c` and `Delay` traits, rather
+/// than the [`embedded_hal`] versions of those traits.
+///
+/// # Notes
+///
+/// The [`AsyncBme680::new`] constructor is not asynchronous, and therefore ---
+/// unlike the  synchronous [`Bme680::new`] --- it does not initialize the
+/// sensor.  Instead, the sensor must be initialized using the
+/// [`AsyncBme680::initialize`] method before reading sensor data. Otherwise,
+/// the [`AsyncBme680::measure`] method will return [`BmeError::Uninitialized`].
+///
+/// [`Bme680::new`]: crate::Bme680::new
+pub struct AsyncBme680<I2C, D> {
+    // actually communicates with sensor
+    i2c: I2CHelper<I2C, D>,
+    state: Option<State>,
+}
+
+struct State {
+    // calibration data that was saved on the sensor
+    calibration_data: CalibrationData,
+    // used to calculate measurement delay period
+    sensor_config: RawConfig<[u8; LEN_CONFIG]>,
+    // needed to calculate the gas resistance since it differs between bme680 and bme688
+    variant: Variant,
+}
+
+impl<I2C, D> AsyncBme680<I2C, D>
+where
+    I2C: I2c<SevenBitAddress>,
+    D: DelayNs,
+{
+    /// Creates a new instance of the Sensor
+    ///
+    /// # Arguments
+    /// * `delayer` - Used to wait for the triggered measurement to finish
+    /// * `ambient_temperature` - Needed to calculate the heater target
+    ///   temperature
+    ///
+    /// # Notes
+    ///
+    /// This constructor is not asynchronous, and therefore --- unlike the
+    /// synchronous [`Bme680::new`] --- it does not initialize the sensor.
+    /// Instead, the sensor must be initialized using the
+    /// [`AsyncBme680::initialize`] method before reading sensor data.
+    /// Otherwise, the [`AsyncBme680::measure`] method  will return
+    /// [`BmeError::Uninitialized`].
+    ///
+    /// [`Bme680::new`]: crate::Bme680::new
+    pub fn new(
+        i2c_interface: I2C,
+        device_address: DeviceAddress,
+        delayer: D,
+        ambient_temperature: i32,
+    ) -> Self {
+        let i2c = I2CHelper::new(i2c_interface, device_address, delayer, ambient_temperature);
+
+        Self { i2c, state: None }
+    }
+
+    pub async fn initialize(&mut self, sensor_config: &Configuration) -> Result<(), BmeError<I2C>> {
+        self.i2c.init().await?;
+        let calibration_data = self.i2c.get_calibration_data().await?;
+        let sensor_config = self
+            .i2c
+            .set_config(sensor_config, &calibration_data)
+            .await?;
+        let variant = self.i2c.get_variant_id().await?;
+        self.state = Some(State {
+            calibration_data,
+            sensor_config,
+            variant,
+        });
+        Ok(())
+    }
+
+    /// Returns the wrapped i2c interface
+    pub fn into_inner(self) -> I2C {
+        self.i2c.into_inner()
+    }
+
+    pub async fn set_configuration(&mut self, config: &Configuration) -> Result<(), BmeError<I2C>> {
+        let state = self.state.as_mut().ok_or(BmeError::Uninitialized)?;
+        self.i2c.set_mode(SensorMode::Sleep).await?;
+        let new_config = self.i2c.set_config(config, &state.calibration_data).await?;
+        // current conf is used to calculate measurement delay period
+        state.sensor_config = new_config;
+        Ok(())
+    }
+    /// Trigger a new measurement.
+    /// # Errors
+    /// If no new data is generated in 5 tries a Timeout error is returned.
+    // Sets the sensor mode to forced
+    // Tries to wait 5 times for new data with a delay calculated based on the set sensor config
+    // If no new data could be read in those 5 attempts a Timeout error is returned
+    pub async fn measure(&mut self) -> Result<MeasurmentData, BmeError<I2C>> {
+        let state = self.state.as_mut().ok_or(BmeError::Uninitialized)?;
+        self.i2c.set_mode(SensorMode::Forced).await?;
+        let delay_period = state.sensor_config.calculate_delay_period_us();
+        self.i2c.delay(delay_period).await;
+        // try read new values 5 times and delay if no new data is available or the sensor is still measuring
+        for _i in 0..5 {
+            let raw_data = self.i2c.get_field_data().await?;
+            match MeasurmentData::from_raw(raw_data, &state.calibration_data, &state.variant) {
+                Some(data) => {
+                    // update the current ambient temperature which is needed to calculate the target heater temp
+                    self.i2c.ambient_temperature = data.temperature as i32;
+                    return Ok(data);
+                }
+                None => self.i2c.delay(delay_period).await,
+            }
+        }
+        // Shouldn't happen
+        Err(BmeError::MeasuringTimeOut)
+    }
+
+    pub fn get_calibration_data(&self) -> Result<&CalibrationData, BmeError<I2C>> {
+        Ok(&self
+            .state
+            .as_ref()
+            .ok_or(BmeError::Uninitialized)?
+            .calibration_data)
+    }
+}
+
+#[cfg(test)]
+mod library_tests {
+    // TODO: embedded_hal_mock doesn't currently have support for the async I2C
+    // trait. When that's added, we should add tests here.
+}

--- a/src/async_impl/i2c_helper.rs
+++ b/src/async_impl/i2c_helper.rs
@@ -1,0 +1,230 @@
+use embedded_hal_async::delay::DelayNs;
+use embedded_hal_async::i2c::{I2c, SevenBitAddress};
+use log::debug;
+
+use crate::bitfields::{CtrlMeasurment, RawConfig, RawData};
+use crate::config::{Configuration, GasConfig, SensorMode, Variant};
+use crate::constants::{
+    ADDRS_CONFIG, ADDR_CONFIG, ADDR_CONTROL_MODE, ADDR_GAS_WAIT_0, ADDR_RES_HEAT_0,
+    ADDR_SENSOR_RESULT, ADDR_VARIANT_ID, DELAY_PERIOD_US, LEN_CONFIG,
+};
+use crate::{
+    config::DeviceAddress,
+    constants::{
+        ADDR_CHIP_ID, ADDR_REG_COEFF1, ADDR_REG_COEFF2, ADDR_REG_COEFF3, ADDR_SOFT_RESET, CHIP_ID,
+        CMD_SOFT_RESET, LEN_COEFF1, LEN_COEFF2, LEN_COEFF_ALL,
+    },
+    data::CalibrationData,
+    error::BmeError,
+    i2c_helper,
+};
+
+pub(crate) struct I2CHelper<I2C, D> {
+    i2c_interface: I2C,
+    address: u8,
+    delayer: D,
+    pub ambient_temperature: i32,
+}
+impl<I2C, D> I2CHelper<I2C, D>
+where
+    I2C: I2c<SevenBitAddress>,
+    D: DelayNs,
+{
+    pub fn new(
+        i2c_interface: I2C,
+        device_address: DeviceAddress,
+        delayer: D,
+        ambient_temperature: i32,
+    ) -> Self {
+        Self {
+            i2c_interface,
+            address: device_address.into(),
+            delayer,
+            // current ambient temperature. Needed to calculate the target temperature of the heater
+            ambient_temperature,
+        }
+    }
+
+    pub fn into_inner(self) -> I2C {
+        self.i2c_interface
+    }
+    // pause for duration in us
+    pub async fn delay(&mut self, duration_us: u32) {
+        self.delayer.delay_us(duration_us).await;
+    }
+    async fn get_register(&mut self, address: u8) -> Result<u8, BmeError<I2C>> {
+        debug!("    Getting register: {address:x}.");
+        let mut buffer = [0; 1];
+        self.i2c_interface
+            .write_read(self.address, &[address], &mut buffer)
+            .await
+            .map_err(BmeError::WriteReadError)?;
+        Ok(buffer[0])
+    }
+    pub async fn get_registers(
+        &mut self,
+        address: u8,
+        buffer: &mut [u8],
+    ) -> Result<(), BmeError<I2C>> {
+        debug!(
+            "   Getting register: {address:x} to {:x}. Length {} bytes.",
+            buffer.len() + address as usize,
+            buffer.len()
+        );
+        self.i2c_interface
+            .write_read(self.address, &[address], buffer)
+            .await
+            .map_err(BmeError::WriteReadError)?;
+        Ok(())
+    }
+    async fn set_register(&mut self, address: u8, value: u8) -> Result<(), BmeError<I2C>> {
+        debug!("    Setting register {address:x} to {value:b}");
+        self.i2c_interface
+            .write(self.address, &[address, value])
+            .await
+            .map_err(BmeError::WriteError)
+    }
+
+    // takes register pairs like [(addr, val), (addr, val)]
+    async fn set_registers_iter<'a>(
+        &mut self,
+        register_pairs: impl Iterator<Item = (&'a u8, &'a u8)>,
+    ) -> Result<(), BmeError<I2C>> {
+        for (address, value) in register_pairs {
+            self.set_register(*address, *value).await?;
+        }
+        Ok(())
+    }
+    /// Soft resets and checks device if device id matches the expected device id
+    pub async fn init(&mut self) -> Result<(), BmeError<I2C>> {
+        self.soft_reset().await?;
+        self.delayer.delay_ms(DELAY_PERIOD_US).await;
+        let chip_id = self.get_chip_id().await?;
+        if chip_id != CHIP_ID {
+            Err(BmeError::UnexpectedChipId(chip_id))
+        } else {
+            Ok(())
+        }
+    }
+    pub async fn soft_reset(&mut self) -> Result<(), BmeError<I2C>> {
+        debug!("Soft resetting");
+        self.set_register(ADDR_SOFT_RESET, CMD_SOFT_RESET).await
+    }
+    async fn get_chip_id(&mut self) -> Result<u8, BmeError<I2C>> {
+        debug!("Getting chip id");
+        self.get_register(ADDR_CHIP_ID).await
+    }
+    pub async fn get_variant_id(&mut self) -> Result<Variant, BmeError<I2C>> {
+        debug!("Getting variant id");
+        Ok(self.get_register(ADDR_VARIANT_ID).await?.into())
+    }
+    // fills buffer with content from 3 seperate reads
+    pub async fn get_calibration_data(&mut self) -> Result<CalibrationData, BmeError<I2C>> {
+        debug!("Getting calibration data");
+        let mut coeff_buffer = [0; LEN_COEFF_ALL];
+        // fill coeff buffer
+        debug!("Filling register buffer 1");
+        self.get_registers(ADDR_REG_COEFF1, &mut coeff_buffer[0..LEN_COEFF1])
+            .await?;
+        debug!("Filling register buffer 2");
+        self.get_registers(
+            ADDR_REG_COEFF2,
+            &mut coeff_buffer[LEN_COEFF1..LEN_COEFF1 + LEN_COEFF2],
+        )
+        .await?;
+        debug!("Filling register buffer 3");
+        self.get_registers(
+            ADDR_REG_COEFF3,
+            &mut coeff_buffer[LEN_COEFF1 + LEN_COEFF2..LEN_COEFF_ALL],
+        )
+        .await?;
+        Ok(i2c_helper::extract_calibration_data(coeff_buffer))
+    }
+    /// Puts the sensor to sleep and adjusts SensorMode afterwards
+    pub async fn set_mode(&mut self, mode: SensorMode) -> Result<(), BmeError<I2C>> {
+        // 1. Read ctr_meas register
+        // 2. Set last 2 bits to 00 (sleep) if not already in sleep mode
+        // 3. Set last 2 bits to 01 (forced) if the requested mode is forced. Do nothing if the requested mode is sleep,
+        // as the sensor has already been sent to sleep before.
+        debug!("Setting mode to {mode:?}");
+        let mut control_register = loop {
+            debug!("Getting control register");
+            let mut control_register = CtrlMeasurment(self.get_register(ADDR_CONTROL_MODE).await?);
+
+            debug!("Current control_register: {control_register:?}");
+            let current_mode = control_register.mode();
+            debug!("Current mode: {current_mode:?}");
+            // Put sensor to sleep unless it already in sleep mode. Same as in the reference implementation
+            match current_mode {
+                SensorMode::Sleep => break control_register,
+                SensorMode::Forced => {
+                    control_register.set_mode(SensorMode::Sleep);
+                    debug!("Setting control register to: {control_register:?}");
+                    self.set_register(ADDR_CONTROL_MODE, control_register.0)
+                        .await?;
+                    self.delayer.delay_ms(DELAY_PERIOD_US).await;
+                }
+            }
+        };
+        debug!("Broke out of loop with control register: {control_register:?}");
+        match mode {
+            SensorMode::Sleep => Ok(()),
+            SensorMode::Forced => {
+                // Change to forced mode. Last two bits=01.
+                control_register.set_mode(SensorMode::Forced);
+                debug!("Setting control register to: {control_register:?}");
+                self.set_register(ADDR_CONTROL_MODE, control_register.0)
+                    .await
+            }
+        }
+    }
+    pub async fn get_config(&mut self) -> Result<RawConfig<[u8; LEN_CONFIG]>, BmeError<I2C>> {
+        debug!("Getting config");
+        let mut buffer = [0; LEN_CONFIG];
+        self.get_registers(ADDR_CONFIG, &mut buffer).await?;
+        Ok(RawConfig(buffer))
+    }
+    /// Gets current config and applies all present values in given config
+    /// Returns the new raw config
+    pub async fn set_config(
+        &mut self,
+        conf: &Configuration,
+        calibration_data: &CalibrationData,
+    ) -> Result<RawConfig<[u8; LEN_CONFIG]>, BmeError<I2C>> {
+        let mut current_conf = self.get_config().await?;
+        current_conf.apply_config(conf);
+
+        let pairs = ADDRS_CONFIG.iter().zip(current_conf.0.iter());
+        debug!("Setting config registers");
+        self.set_registers_iter(pairs).await?;
+        if let Some(gas_conf) = &conf.gas_config {
+            self.set_gas_config(gas_conf, calibration_data).await?;
+        }
+        Ok(current_conf)
+    }
+    async fn set_gas_config(
+        &mut self,
+        gas_config: &GasConfig,
+        calibration_data: &CalibrationData,
+    ) -> Result<(), BmeError<I2C>> {
+        let gas_wait = gas_config.calc_gas_wait();
+        let res_heat = gas_config.calc_res_heat(calibration_data, self.ambient_temperature);
+        debug!("Setting gas_wait_0 to {gas_wait}");
+        debug!("Setting res_heat_0 to {res_heat}");
+        self.set_register(ADDR_GAS_WAIT_0, gas_wait).await?;
+        self.set_register(ADDR_RES_HEAT_0, res_heat).await?;
+        Ok(())
+    }
+    /// Get raw sensor data. 15 bytes starting at 0x1D
+    pub async fn get_field_data(&mut self) -> Result<RawData<[u8; 15]>, BmeError<I2C>> {
+        let mut buffer: [u8; 15] = [0; 15];
+        self.get_registers(ADDR_SENSOR_RESULT, &mut buffer).await?;
+        Ok(RawData(buffer))
+    }
+}
+
+#[cfg(test)]
+mod i2c_tests {
+    // TODO: embedded_hal_mock doesn't currently have support for the async I2C
+    // trait. When that's added, we should add tests here.
+}

--- a/src/bitfields.rs
+++ b/src/bitfields.rs
@@ -49,6 +49,24 @@ impl RawConfig<[u8; 5]> {
             self.set_heater_profile(HeaterProfile::Profile0);
         }
     }
+
+    pub(crate) fn calculate_delay_period_us(&self) -> u32 {
+        use crate::constants::{
+            CYCLE_DURATION, GAS_MEAS_DURATION, TPH_SWITCHING_DURATION, WAKEUP_DURATION,
+        };
+        let mut measurement_cycles: u32 = 0;
+        measurement_cycles += self.temperature_oversampling().cycles();
+        measurement_cycles += self.humidity_oversampling().cycles();
+        measurement_cycles += self.pressure_oversampling().cycles();
+
+        let mut measurement_duration = measurement_cycles * CYCLE_DURATION;
+        measurement_duration += TPH_SWITCHING_DURATION;
+        measurement_duration += GAS_MEAS_DURATION;
+
+        measurement_duration += WAKEUP_DURATION;
+
+        measurement_duration
+    }
 }
 
 bitfield! {

--- a/src/data.rs
+++ b/src/data.rs
@@ -55,7 +55,7 @@ impl MeasurmentData {
         variant: &crate::config::Variant,
     ) -> Option<Self> {
         // First, check to make sure a measurement is ready. If not, bail.
-        if raw_data.measuring() || raw_data.new_data() {
+        if raw_data.measuring() && !raw_data.new_data() {
             return None;
         }
         let (temperature, t_fine) =

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,10 @@
 use core::fmt::Formatter;
-use embedded_hal::i2c::{I2c, SevenBitAddress};
-
+use embedded_hal::i2c::ErrorType;
 
 /// All possible errors
 pub enum BmeError<I2C>
 where
-    I2C: I2c<SevenBitAddress>
+    I2C: ErrorType,
 {
     /// Error during I2C write operation.
     WriteError(I2C::Error),
@@ -16,11 +15,14 @@ where
     /// After running the measurment the sensor blocks until the 'new data bit' of the sensor is set.
     /// Should this take more than 5 tries an error is returned instead of incorrect data.
     MeasuringTimeOut,
+    /// An [`AsyncBme680`](crate::AsyncBme680) has not yet been initialized.
+    #[cfg(feature = "embedded-hal-async")]
+    Uninitialized,
 }
 
 impl<I2C> core::fmt::Debug for BmeError<I2C>
 where
-    I2C: I2c<SevenBitAddress>
+    I2C: ErrorType,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::result::Result<(), core::fmt::Error> {
         match self {
@@ -31,7 +33,8 @@ where
                 .field(chip_id)
                 .finish(),
             BmeError::MeasuringTimeOut => f
-                .debug_tuple("Timed out while waiting for new measurement values. Either no new data or the sensor took unexpectedly long to finish measuring.").finish()
+                .debug_tuple("Timed out while waiting for new measurement values. Either no new data or the sensor took unexpectedly long to finish measuring.").finish(),
+            BmeError::Uninitialized => f.debug_tuple("Uninitialized").finish(),
         }
     }
 }


### PR DESCRIPTION
This commit adds support for the `embedded-hal-async` crate in addition to `embedded-hal`. I've done this by adding a separate `AsyncSgp30` type, based on the assumption that most projects won't need to use both the blocking `embedded-hal` traits and the `embedded-hal-async` traits at the same time, and providing `async fn` methods on a separate type with the same names as the blocking ones seemed a bit nicer than having one type that has async methods suffixed with `_async` or similar.

In order to make this change, I've factored out some code into functions on `MeasurmentData` and `RawConfig` so that they can be shared between the blocking and async implementations.

Support for `embedded-hal-async` is gated behind the `embedded-hal-async` feature flag, so the dependency is not enabled by default. Therefore, I've also added documentation about the feature flag, and configured docs.rs to build the documentation with the `doc_cfg` and `doc_auto_cfg` features enabled, so that the documentation clearly shows which types require the feature flag.

Thanks for implementing the driver! Please let me know if you have any questions about this PR.