### PR TITLE
feat: add `GasConfig::new`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -118,6 +118,14 @@ impl Default for GasConfig {
     }
 }
 impl GasConfig {
+    #[must_use]
+    pub fn new(heater_duration: Duration, heater_target_temperature: u16) -> Self {
+        Self {
+            heater_duration,
+            heater_target_temperature,
+        }
+    }
+
     #[must_use] pub fn calc_gas_wait(&self) -> u8 {
         let mut duration = self.heater_duration.as_millis() as u16;
         let mut factor: u8 = 0;


### PR DESCRIPTION
Bosch's BSEC library requests specific values for the gas config. Previously, you couldn't create a gas config with these values.
This PR adds `GasConfig::new` which takes `heater_duration` and `heater_target_temperature` and just stores them.